### PR TITLE
add disclaimer for non-French article list

### DIFF
--- a/pure/templates/index.html
+++ b/pure/templates/index.html
@@ -14,10 +14,14 @@
                 {% endif %}
                 <h1 class="content-subhead">
                     {% block pagetitle %}
-                        {% if not articles_page.has_previous() %}
-                            Derniers articles
+                        {% if DEFAULT_LANG == 'fr' %}
+                            {% if not articles_page.has_previous() %}
+                                Derniers articles
+                            {% else %}
+                                Articles
+                            {% endif %}
                         {% else %}
-                            Articles
+                            Articles which have been translated into English.
                         {% endif %}
                     {% endblock pagetitle %}
                     {% if articles_page.has_previous() %}


### PR DESCRIPTION
I went through a number of iterations on this in terms of wording, placement, font size, and so forth. I feel that this is a good option because it is succinct, obvious, and fits well with the established theme.

![screen shot 2015-08-11 at 17 46 54](https://cloud.githubusercontent.com/assets/625232/9202227/2522ddd0-4051-11e5-871d-deb455091c19.png)

`r?`
